### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete regular expression for hostnames

### DIFF
--- a/dnsanalyzer.go
+++ b/dnsanalyzer.go
@@ -1184,7 +1184,7 @@ func (a *DNSAnalyzer) detectTechnologies() {
     webTechPatterns := map[string]string{
         "HTML5":           `<!DOCTYPE html>`,
         "CSS3":            `@media|@font-face|@keyframes`,
-        "Web Fonts":       `fonts.googleapis.com|font-family`,
+        "Web Fonts":       `fonts\.googleapis\.com|font-family`,
         "Responsive Design": `@media \(max-width|viewport`,
         "AJAX":           `XMLHttpRequest|fetch\(`,
         "JSON":           `application/json|JSON\.parse`,


### PR DESCRIPTION
Potential fix for [https://github.com/rexdivakar/dnsc/security/code-scanning/6](https://github.com/rexdivakar/dnsc/security/code-scanning/6)

To fix the problem, we need to escape the dot in the regular expression to ensure it matches the literal dot character rather than any character. This can be done by replacing `.` with `\.`. Additionally, using raw string literals can make the regular expression more readable and avoid the need to escape backslashes.

- Update the regular expression in the `webTechPatterns` map on line 1187 to escape the dot before `googleapis.com`.
- Use a raw string literal for the regular expression to improve readability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fixes a code scanning alert by escaping the dot in the regular expression to match the literal dot character.